### PR TITLE
Fix script when using in bash strict mode

### DIFF
--- a/bash_colors.sh
+++ b/bash_colors.sh
@@ -54,7 +54,7 @@ function clr_layer
     ARGS=("$@")
 
     # iterate over arguments in reverse
-    for ((i=$#; i>=0; i--)); do
+    for ((i=$#-1; i>=0; i--)); do
         ARG=${ARGS[$i]}
         # echo $ARG
         # set CLR_VAR as last argtype

--- a/bash_colors.sh
+++ b/bash_colors.sh
@@ -2,7 +2,12 @@
 #
 # Constants and functions for terminal colors.
 # Author: Max Tsepkov <max@yogi.pw>
-
+if [[ "$BASH_SOURCE" == "$0" ]]; then
+    is_script=true
+    set -eu -o pipefail
+else
+    is_script=false
+fi
 CLR_ESC="\033["
 
 # All these variables has a function with the same name, but in lower case.
@@ -175,3 +180,6 @@ function clr_dump
 '
 }
 
+if [[ "$is_script" == "true" ]]; then
+    clr_dump
+fi


### PR DESCRIPTION
Script is returning an error when executed in bash strict mode because it iterates over an undefined index in the for loop inside `clr_layer` function.
As a bonus, the script could now be executed as a standalone script and output the `clr_dump` function, behaving as before when used inside another script.